### PR TITLE
feat: add impl for avoiding the no_rows error occurred by LAST_INSERT_ROW

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -77,7 +77,8 @@ func (r *ItemDBRepository) AddItem(ctx context.Context, item domain.Item) (domai
 	}
 	// TODO: if other insert query is executed at the same time, it might return wrong id
 	// http.StatusConflict(409) 既に同じIDがあった場合
-	row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE rowid = LAST_INSERT_ROWID()")
+	// row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE rowid = LAST_INSERT_ROWID()")
+	row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE name=? AND price=? ORDER BY rowid DESC LIMIT 1", item.Name, item.Price)
 
 	var res domain.Item
 	return res, row.Scan(&res.ID, &res.Name, &res.Price, &res.Description, &res.CategoryID, &res.UserID, &res.Image, &res.Status, &res.CreatedAt, &res.UpdatedAt)


### PR DESCRIPTION
## What
AddItemにおいて、LAST_INSERT_ROWを利用しないような類似のクエリに置き換える

## Why
トランザクションを張っていないので、同時にAddItemが呼ばれると正しくないItemIDを返す現象が起きていたため
トランザクションを張るとDBに対するロックがかかるが、SQLiteはファイルでDBを管理しているため、毎回DB全体にロックがかかるという問題がある

そこで、回避策として、LAST_INSERT_ROWを利用しないような類似のクエリに置き換えることとする

For more details: https://mercari.slack.com/archives/C02GAR0K5SP/p1685211220681539